### PR TITLE
Added Set-WorkflowInConfigureMode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2016, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     needs: build
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@ Output
 docs/Functions
 Tests/tmp
 coverage.xml
-Coverage-Pester.xml
-Test-Pester.XML
-Test-Pester.xml
+coverage.xml
+testResults.xml
+testResults.xml
 site/
 .DS_Store
 tmp

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
   - job: BuildModule
 
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-latest
       #vmImage: 'ubuntu-latest'
 
     steps:
@@ -36,14 +36,14 @@ jobs:
         condition: always()
         inputs:
           codeCoverageTool: 'JaCoCo'
-          summaryFileLocation: '**/Coverage-Pester.xml'
+          summaryFileLocation: '**/coverage.xml'
           pathToSources: '$(System.DefaultWorkingDirectory)/src/Scriptbook/Public'
 
       - task: PublishTestResults@2
         condition: always()
         inputs:
           testRunner: 'NUnit'
-          testResultsFiles: '**/Test-Pester.XML'
+          testResultsFiles: '**/testResults.xml'
           testRunTitle: 'Module'
           failTaskOnFailedTests: true
         displayName: 'Publish Test Results'
@@ -75,14 +75,14 @@ jobs:
         condition: always()
         inputs:
           codeCoverageTool: 'JaCoCo'
-          summaryFileLocation: '**/Coverage-Pester.xml'
+          summaryFileLocation: '**/coverage.xml'
           pathToSources: '$(System.DefaultWorkingDirectory)/src/Scriptbook/Public'
 
       - task: PublishTestResults@2
         condition: always()
         inputs:
           testRunner: 'NUnit'
-          testResultsFiles: '**/Test-Pester.XML'
+          testResultsFiles: '**/testResults.xml'
           testRunTitle: 'Module'
           failTaskOnFailedTests: true
         displayName: 'Publish Test Results'

--- a/build/build.scriptbook.ps1
+++ b/build/build.scriptbook.ps1
@@ -126,9 +126,17 @@ Action Test {
     try
     {
         Assert-Version dotnet 3.0 -Minimum
-        $loc = Get-Location
-        $r = Invoke-Pester -Script $loc -PassThru -OutputFile "$loc/Test-Pester.xml" -OutputFormat 'JUnitXML' -ExcludeTagFilter 'e2e'
-        Show-PesterOutput $r
+
+        $config = [PesterConfiguration]::Default
+        $config.TestResult.Enabled = $true
+        $config.CodeCoverage.Enabled = $true
+        $config.CodeCoverage.Path = (Join-Path (Get-Location) './../Scriptbook')
+        $config.CodeCoverage.OutputFormat = 'JaCoCo'
+        $config.CodeCoverage.CoveragePercentTarget = 50 #75
+        $config.Run.PassThru = $true
+        $config.Run.Throw = $false
+        $config.Output.Verbosity = 'Detailed'
+        $r = Invoke-Pester -Configuration $config
         $Script:TestResult = $r.Result -eq 'Passed'
     }
     finally
@@ -230,10 +238,18 @@ Action Publish -If {$Publish} {
     }
 }
 
+Action Finish -If {!$Publish} {
+    if (!$Script:TestResult)
+    {
+        Throw "Tests failed. Check test results."
+    }
+}
+
+$containerSupport = $false
 $options = @{}
 if (!$env:SYSTEM_TEAMPROJECT -and !$env:GITHUB_ACTIONS)
 {
-    $options = @{Container = $true; ContainerOptions = @{Root = '..'; Isolated = $true } }
+    $options = @{Container = $containerSupport; ContainerOptions = @{Root = '..'; Isolated = $true } }
 }
 
 if ($env:SYSTEM_ACCESSTOKEN)

--- a/build/build.scriptbook.ps1
+++ b/build/build.scriptbook.ps1
@@ -129,7 +129,8 @@ Action Test {
 
         $config = [PesterConfiguration]::Default
         $config.TestResult.Enabled = $true
-        $config.CodeCoverage.Enabled = $true
+        $config.TestResult.OutputFormat = 'JUnitXml'
+        $config.CodeCoverage.Enabled = $false
         $config.CodeCoverage.Path = (Join-Path (Get-Location) './../Scriptbook')
         $config.CodeCoverage.OutputFormat = 'JaCoCo'
         $config.CodeCoverage.CoveragePercentTarget = 50 #75

--- a/docs/Getting Started/Scriptbook Parameters & Variables.md
+++ b/docs/Getting Started/Scriptbook Parameters & Variables.md
@@ -1,10 +1,10 @@
 # Scriptbook Parameters and Variables
 
-The default way of using parameters and variables in Scriptbook is the PowerShell way
+The default way of using parameters and variables in Scriptbook is the PowerShell way with param blocks and local, script and global scopes.
 
 ## Parameters
 
-In Scriptbook file you pass parameters to Workflow via Param block
+In Scriptbook file you pass parameters to Workflow via Param block of script file
 
 ```powershell
 param(
@@ -30,13 +30,13 @@ $myItemValue = 100
 
 ```
 
-## Access Parameters and Variables
+## Access PowerShell Parameters and Variables
 
-Parameters and Variables are added to the file/script Scope and accessible via $Script:VarName or $varName when reading variable only
+PowerShell parameters and variables are added to the file/script Scope and accessible via $Script:VarName or $varName when reading variable
 
-At file or script(book) level you can read and write to variables with the $myVar normal PowerShell syntax
+At file or script(book) level you can read and write to variables with the '$myVar' normal PowerShell syntax
 
-At the Action level you can read variables with the $myVar syntax but modifying the variable requires script syntax --> $Script:myVar = 50
+At the Action level you can read variables with the '$myVar' syntax but modifying the variable requires script scope syntax --> $Script:myVar = 50
 
 ## Parameter and Variable naming conventions
 
@@ -44,7 +44,7 @@ It's custom for Parameters to use PascalCasing with where each word in the param
 
 ## Passing parameters with PowerShell HashTables
 
-Another way to pass parameters to Scriptbook is by using PowerShell HashTables @{}. This way you can pass easy a whole bunch of parameters and organize them in logical groups.
+Another way to pass parameters to Scriptbook is by using PowerShell HashTables @{}. This way you can easy pass a whole bunch of parameters and organize them in logical groups.
 
 ```powershell
 param(
@@ -64,6 +64,10 @@ $myItemValue = $Item.Value
 ## PowerShell Variable Scoping and PowerShell ScriptBlock
 
 Scriptbook is a PowerShell DSL or as I would say Scriptbook is PowerShell in it's Core. That's why Scriptbook uses the same scoping rules as PowerShell.
+
+## Alternative way to handle Parameters and Variables in Scriptbook
+
+Another way to handle Parameters and Variables in Scriptbook workflow is by using the Parameters and Variables definitions. See more details by using the Scriptbook [Workflow Context]('./Scriptbook Workflow Context.md'). Using these methods the preferred ways is to use PowerShell Variables for controlling and starting of the workflow and the Parameters and variables definition for the workflow details.
 
 References:
 

--- a/docs/Getting Started/Scriptbook Workflow Context.md
+++ b/docs/Getting Started/Scriptbook Workflow Context.md
@@ -4,6 +4,8 @@ A Scriptbook Workflow contains Data & Actions. Data is represented by parameters
 
 By introducing Scriptbook Workflow Parameters & Variables functions you can organize your parameters and variables easier and have support for loading and saving parameter values to a file. The state of your Parameters and Variables are stored in the workflow context during the execution of your Scriptbook workflow.
 
+For sample Parameters definition and access to Parameters see snippet below. You can add more than one Parameters definition to workflow by Name.
+
 ```powershell
 Parameters -Name 'DefaultParameters' -Path './DefaultParameters.json' {
     @{
@@ -30,3 +32,5 @@ $ctx = Get-WorkflowContext
 $ctx.DefaultParameters.Store.Name
 
 ```
+
+When including the -Path option you can load the parameters from a json file and edit them outside your workflow. You can also edit the Parameters when running the Scriptbook in configure mode or setting the Set-WorkflowInConfigureMode to $true.  

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,26 @@
 ![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/Scriptbook.svg?label=PSGallery%20Downloads&logo=PowerShell&style=flat-square)
 [![Build Status](https://dev.azure.com/tedon/TD.Deploy/_apis/build/status/ehagen.Scriptbook?branchName=master)](https://dev.azure.com/tedon/TD.Deploy/_build/latest?definitionId=52&branchName=master)
 
+## [0.6.0]
+
+```plain
+### Added
+
+- Added Set-WorkflowInConfigureMode
+- Added $ConfigurePreference & Edit Scriptbook parameters in Console Host (use -Configure parameter on Start-Scriptbook)
+- Added AsJob support to Start-Scriptbook
+- Added secure storage of secrets in json files to read/save parameters (from TD.Util)
+- Added not (!) support to Action expansion
+- Added warning loading Scriptbook module twice
+- Added Get-IsPowerShellStartedInNonInteractiveMode (Check running in console mode)
+- Added verbose support to Start-Workflow
+- Added verbose support to Out-Null (visible when in verbose mode)
+
+### Changed
+- Updated to Pester 5.* with code-coverage
+
+```
+
 ## [0.5.5]
 
 ```plain

--- a/src/Scriptbook/Private/Expand-WorkflowActions.ps1
+++ b/src/Scriptbook/Private/Expand-WorkflowActions.ps1
@@ -1,5 +1,8 @@
-function Expand-WorkflowActions($Actions)
+function Expand-WorkflowActions
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
+    param($Actions)
+
     $ctx = Get-RootContext
     $expandedActions = [System.Collections.ArrayList]@()
     foreach ($action in $Actions)
@@ -11,7 +14,7 @@ function Expand-WorkflowActions($Actions)
                 $n = $item.Value.DisplayName
                 if ($n -like $action)
                 {
-                    if (!$expandedActions.Contains($n))
+                    if (!$expandedActions.Contains($n) -and !$expandedActions.Contains("!$n"))
                     {
                         [void]$expandedActions.Add($n)
                     }

--- a/src/Scriptbook/Private/Get-AnsiColoredString.ps1
+++ b/src/Scriptbook/Private/Get-AnsiColoredString.ps1
@@ -1,5 +1,8 @@
-function Get-AnsiColoredString([string]$String, [ValidateNotNull()][int]$Color, [switch]$NotSupported)
+function Get-AnsiColoredString
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "")]
+    param([string]$String, [ValidateNotNull()][int]$Color, [switch]$NotSupported)
+
     # ref: https://en.wikipedia.org/wiki/ANSI_escape_code for color codes 
     # ref: https://duffney.io/usingansiescapesequencespowershell/
     if ($Global:ScriptbookSimpleHost -or $NotSupported.IsPresent)

--- a/src/Scriptbook/Private/Invoke-ActionSequence.ps1
+++ b/src/Scriptbook/Private/Invoke-ActionSequence.ps1
@@ -31,10 +31,18 @@ function Invoke-ActionSequence
         $hasDepends = $true
         if (!$HasDepends)
         {
-            $mp = (Get-Module Scriptbook).Path
+            $module = Get-Module Scriptbook
+            if ($module)
+            {
+                $mp = $module.Path
+            }
+            else
+            {
+                throw "Module scriptbook loaded more than one time. Only Import Scriptbook Module once."
+            }
             $globalScriptVariables = Get-GlobalVarsForScriptblock -AsHashTable
             $rc = Get-RootContext
-            $Actions | Where-Object { $_.NoSequence -eq $false} | ForEach-Object -Parallel {
+            $Actions | Where-Object { $_.NoSequence -eq $false } | ForEach-Object -Parallel {
                 $vars = $using:globalScriptVariables
                 foreach ($v in $vars.GetEnumerator())
                 {

--- a/src/Scriptbook/Private/Invoke-AlwaysActions.ps1
+++ b/src/Scriptbook/Private/Invoke-AlwaysActions.ps1
@@ -1,6 +1,7 @@
 function Invoke-AlwaysActions
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         $Actions,

--- a/src/Scriptbook/Private/Invoke-Perform.ps1
+++ b/src/Scriptbook/Private/Invoke-Perform.ps1
@@ -4,7 +4,8 @@
 #>
 function Invoke-Perform
 {
-    [CmdletBinding(SupportsShouldProcess = $True)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+        [CmdletBinding(SupportsShouldProcess = $True)]
     param (
         [string][alias('c')]$Command,
         $Code = $null,
@@ -225,7 +226,15 @@ function Invoke-Perform
                 $mp = $null
                 if (!$Isolated.IsPresent)
                 {
-                    $mp = (Get-Module Scriptbook).Path
+                    $module = Get-Module Scriptbook
+                    if ($module)
+                    {
+                        $mp = $module.Path
+                    }
+                    else
+                    {
+                        throw "Module scriptbook loaded more than once. Only Import Scriptbook Module one time."
+                    }
                 }
 
                 if ($For)

--- a/src/Scriptbook/Private/Invoke-SetupActions.ps1
+++ b/src/Scriptbook/Private/Invoke-SetupActions.ps1
@@ -1,6 +1,7 @@
 function Invoke-SetupActions
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         $Actions,

--- a/src/Scriptbook/Private/New-RootContext.ps1
+++ b/src/Scriptbook/Private/New-RootContext.ps1
@@ -23,17 +23,19 @@ function New-RootContext
         }
 
         New-Object PSObject -Property @{
-            Actions         = $actions
-            ActionSequence  = $actionSequence
-            IndentLevel     = -1
-            NoLogging       = $false
-            Id              = New-Guid
-            InAction        = $false
-            NestedActions   = New-Object -TypeName 'System.Collections.ArrayList'
-            UniqueIdCounter = 1
-            Infos           = $infos
-            Notifications   = $notifications
-            InTest          = $false
+            Actions             = $actions
+            ActionSequence      = $actionSequence
+            IndentLevel         = -1
+            NoLogging           = $false
+            Id                  = New-Guid
+            InAction            = $false
+            NestedActions       = New-Object -TypeName 'System.Collections.ArrayList'
+            UniqueIdCounter     = 1
+            Infos               = $infos
+            Notifications       = $notifications
+            InTest              = $false
+            ConfigurePreference = $false
+            Verbose             = $false
         }    
     }
 }

--- a/src/Scriptbook/Private/Read-ParameterValuesInternal.ps1
+++ b/src/Scriptbook/Private/Read-ParameterValuesInternal.ps1
@@ -1,0 +1,51 @@
+function Read-ParameterValuesInternal
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
+        [CmdletBinding()]
+    param(
+        [ValidateNotNullOrEmpty()]
+        $Path
+    )
+
+    $result = @{}
+    $result = Get-Content -Path $Path | ConvertFrom-Json
+
+    function Set-Props
+    {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+        param($Object)
+        
+        foreach ($prop in $Object.PsObject.Properties)
+        {
+            if ($prop.Value -is [HashTable])
+            {
+                if ($prop.Value.ContainsKey('TypeName') -and ($prop.Value.TypeName -eq 'SecureStringStorage') )
+                {
+                    $prop.Value = [SecureStringStorage]$prop.Value
+                }
+            }
+            elseif ($prop.Value -is [PSCustomObject])
+            {
+                if ($prop.Value.TypeName -and ($prop.Value.TypeName -eq 'SecureStringStorage') )
+                {
+                    $prop.Value = [SecureStringStorage]$prop.Value
+                }
+                else
+                {
+                    Set-Props $prop.Value
+                }
+            }
+        }
+    }
+    
+    # fix SecureString references
+    Set-Props $result
+    
+    $ht = [ordered]@{}
+    foreach ($prop in $result.PSObject.Properties.Name )
+    {
+        [void]$ht.Add($prop, $result.$prop)
+    }
+    
+    return $ht
+}

--- a/src/Scriptbook/Private/Write-ScriptLog.ps1
+++ b/src/Scriptbook/Private/Write-ScriptLog.ps1
@@ -1,12 +1,12 @@
 function Write-ScriptLog($Msg, [switch]$AsError, [switch]$AsWarning, [switch]$AsAction, [switch]$AsWorkflow, [switch]$AsSkipped, [switch]$Verbose)
 {
     $ctx = Get-RootContext
-    if ($ctx.NoLogging -and ($VerbosePreference -ne 'Continue') )
+    if ($ctx.NoLogging -and $ctx.Verbose )
     {
         return
     }
 
-    if ($Verbose.IsPresent -and ($VerbosePreference -ne 'Continue'))
+    if ($Verbose.IsPresent -and $ctx.Verbose)
     {
         return
     }
@@ -44,9 +44,9 @@ function Write-ScriptLog($Msg, [switch]$AsError, [switch]$AsWarning, [switch]$As
             $Msg.Remove('command');
         }
         Write-Info $m @colors; Global:Write-OnLog -Msg $m
-        if ($VerbosePreference -eq 'Continue') 
+        if ($ctx.Verbose) 
         {
-            Write-Info ($Msg.GetEnumerator() | Sort-Object -Property Name | ForEach-Object { '@{0}:{1}' -f $_.key, $_.value }) @colors
+            Write-Info ($Msg.GetEnumerator() | Sort-Object -Property Name | ForEach-Object { 'VERBOSE: @{0}:{1}' -f $_.key, $_.value }) -ForegroundColor Yellow
         }
     }
     else

--- a/src/Scriptbook/Public/Scriptbook/Action.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Action.ps1
@@ -99,6 +99,7 @@ Set-Alias -Name Teardown -Value Action -Scope Global -Force -WhatIf:$false -Conf
 
 function Action
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSupportsShouldProcess", "")]
     param(
         [Parameter(Mandatory = $true, Position = 0)][string] $Name,
         [String[]] $Tag = @(),

--- a/src/Scriptbook/Public/Scriptbook/Edit-WorkflowParameters.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Edit-WorkflowParameters.ps1
@@ -1,0 +1,28 @@
+<#
+.SYNOPSIS
+Edit the workflow parameters defined in the workflow via the host console
+
+.DESCRIPTION
+Edit the workflow parameters defined in the workflow via the host console. 
+
+.PARAMETER Name
+Name of the Parameters Set
+
+.PARAMETER Path
+Storage location of Parameters values in json format
+
+.PARAMETER Notice
+Message to show in Console Host before getting values from user
+
+#>
+function Edit-WorkflowParameters
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
+    param($Name, $Path, $Notice)
+
+    Read-ParameterValuesFromHost -Name $Name -Notice $Notice
+    if ($null -ne $Path)
+    {
+        Save-ParameterValues -Name $Name -Path $Path
+    }
+}

--- a/src/Scriptbook/Public/Scriptbook/Get-WorkflowContext.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Get-WorkflowContext.ps1
@@ -12,9 +12,12 @@ $ctx = Get-WorkflowContext
 #>
 function Get-WorkflowContext
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "")]
+    param()
+    
     if (!(Get-Variable -Name Context -ErrorAction Ignore -Scope Global))
     {
-        Set-Variable -Name Context -Value @{ } -Scope Global
+        Set-Variable -Name Context -Value @{ } -Scope Global -WhatIf:$false
     }
     return $Global:Context
 }

--- a/src/Scriptbook/Public/Scriptbook/Import-Action.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Import-Action.ps1
@@ -47,6 +47,7 @@ Set-Alias -Name Import-Step -Value Import-Action -Scope Global -Force -WhatIf:$f
 #Set-Alias -Name Import-Flow -Value Import-Action -Scope Global -Force -WhatIf:$false
 function Import-Action
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
     [CmdletBinding()]
     param (
         [ValidateNotNullOrEmpty()]

--- a/src/Scriptbook/Public/Scriptbook/Out-ScriptbookNull.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Out-ScriptbookNull.ps1
@@ -1,0 +1,35 @@
+<#
+.SYNOPSIS
+Writes to the Verbose stream if -Verbose
+
+.DESCRIPTION
+Writes to the verbose stream if -Verbose present
+
+.PARAMETER InputObject
+Value to write to verbose stream
+
+.EXAMPLE
+
+'Hello' | Out-ScriptbookVerbose
+
+#>
+
+Set-Alias -Name Out-Null -Value Out-ScriptbookVerbose -Scope Global -Force -WhatIf:$false
+function Out-ScriptbookVerbose
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseProcessBlockForPipelineCommand", "")]
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline = $true)]
+        [object]
+        $InputObject
+    )
+    if ($InputObject)
+    {
+        $ctx = Get-RootContext
+        if ($ctx.Verbose -or $Global:VerbosePreference -eq 'Continue' )
+        {
+            Write-Verbose ($InputObject | Out-String) -Verbose
+        }
+    }
+}

--- a/src/Scriptbook/Public/Scriptbook/Read-ParameterValues.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Read-ParameterValues.ps1
@@ -18,6 +18,8 @@ Read-ParameterValues -Name 'Params' -Path './my-parameter-values.json'
 #>
 function Read-ParameterValues
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [ValidateNotNullOrEmpty()]
@@ -28,8 +30,7 @@ function Read-ParameterValues
 
     if ($PSCmdlet.ShouldProcess("Read-ParameterValues"))
     {
-        # TODO Add SecureStringStorage support
-        $internalValue = Get-Content -Path $Path | ConvertFrom-Json -AsHashtable
+        $internalValue = Read-ParameterValuesInternal -Path $Path
 
         if (!(Get-Variable -Name Context -ErrorAction Ignore -Scope Global))
         {

--- a/src/Scriptbook/Public/Scriptbook/Read-ParameterValuesFromHost.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Read-ParameterValuesFromHost.ps1
@@ -15,43 +15,88 @@ Read-ParameterValuesFromHost -Name 'Params'
 #>
 function Read-ParameterValuesFromHost
 {
-    [CmdletBinding(SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]    
+    [CmdletBinding()]
     param(
         [ValidateNotNullOrEmpty()]
-        [string]$Name
+        [string]$Name,
+        [string]$Notice
     )
 
-    if ($PSCmdlet.ShouldProcess("Read-ParameterValuesFromHost"))
-    {
-        $internalValue = @{}
+    $internalValue = [ordered]@{}
 
-        $ctx = Get-WorkflowContext
-        if ($ctx.ContainsKey($Name))
+    $ctx = Get-WorkflowContext
+    if ($ctx.ContainsKey($Name))
+    {
+        Write-Host ''
+        if ($Notice)
         {
-            # TODO Add SecureStringStorage support
-            foreach ($parameter in $ctx[$Name].GetEnumerator())
+            Write-Host '==========================================================================' -ForegroundColor Blue
+            Write-Host "$Notice $(if ($WhatIfPreference) { '(WhatIf)' })" -ForegroundColor Blue
+        }
+        Write-Host '==========================================================================' -ForegroundColor Blue
+        Write-Host " Enter '$Name' data fields or use default value with [enter] key."
+        Write-Host '   Use [shift][insert] keys if default Paste key is not working.'
+        Write-Host '==========================================================================' -ForegroundColor Blue
+        $l = 0
+        foreach ($parameter in $ctx[$Name].GetEnumerator())
+        {
+            if ($parameter.Key.Length -gt $l)
             {
-                $result = Read-Host -Prompt "$($Parameter.Key): default value = $($parameter.Value)"
-                if (![string]::IsNullOrEmpty($result))
+                $l = $parameter.Key.Length
+            }
+        }
+        foreach ($parameter in $ctx[$Name].GetEnumerator())
+        {
+            $key = $parameter.Key.PadLeft($l)
+            $secret = $false
+            if ($null -ne $parameter.Value)
+            {
+                $secret = ($parameter.Value -is [SecureString]) -or (Test-IsSecureStringStorageObject $parameter.Value)
+            }
+            if ($secret)
+            {
+                $defaultValue = '***********'
+            }
+            else
+            {
+                $defaultValue = $parameter.Value
+            }
+            if (!($WhatIfPreference) )
+            {
+                $result = Read-Host -Prompt "$Key [$(Get-AnsiColoredString -String $defaultValue -Color 93)]"
+            }
+            else
+            {
+                $result = $null
+            }
+            if (![string]::IsNullOrEmpty($result))
+            {
+                if ($secret)
                 {
-                    [void]$internalValue.Add($parameter.Key, $result)
+                    [void]$internalValue.Add($parameter.Key, (ConvertTo-SecureString -String $result -AsPlainText))
                 }
                 else
                 {
-                    [void]$internalValue.Add($parameter.Key, $parameter.Value)
+                    [void]$internalValue.Add($parameter.Key, $result)
                 }
-            }            
+            }
+            else
+            {
+                [void]$internalValue.Add($parameter.Key, $parameter.Value)
+            }
         }
-        else
-        {
-            Throw "Invalid Parameters name found, '$Name' not does not exists"
-        }
-
-        if (!(Get-Variable -Name Context -ErrorAction Ignore -Scope Global))
-        {
-            Set-Variable -Name Context -Value @{ } -Scope Global
-        }
-        $Global:Context."$Name" = $internalValue
-        Set-Variable -Name $Name -Value $internalValue -Scope Global    
     }
+    else
+    {
+        Throw "Invalid Parameters name found, '$Name' not does not exists"
+    }
+
+    if (!(Get-Variable -Name Context -ErrorAction Ignore -Scope Global))
+    {
+        Set-Variable -Name Context -Value @{ } -Scope Global -WhatIf:$false
+    }
+    $Global:Context."$Name" = $internalValue
+    Set-Variable -Name $Name -Value $internalValue -Scope Global -WhatIf:$false
 }

--- a/src/Scriptbook/Public/Scriptbook/Register-Action.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Register-Action.ps1
@@ -37,6 +37,7 @@ Register-Action
 #>
 function Register-Action
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSupportsShouldProcess", "")]
     [OutputType([System.Void])]
     param(
         [Parameter(Mandatory = $true, Position = 0)][string][ValidateNotNullOrEmpty()]$Name,

--- a/src/Scriptbook/Public/Scriptbook/Set-WorkflowInConfigureMode.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Set-WorkflowInConfigureMode.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Set the workflow in configure Mode and enables interactive use.
+
+.DESCRIPTION
+Set the workflow in configure Mode and enables interactive use. Enables reading Parameters from Console.
+
+.PARAMETER Value
+Set Configure Mode On/Off
+
+.EXAMPLE
+
+Set-WorkflowInConfigureMode $true
+
+#>
+function Set-WorkflowInConfigureMode
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "")]
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [bool]$Value
+    )
+
+    if ($Value)
+    {
+        if (Get-IsPowerShellStartedInNonInteractiveMode)
+        {
+            Throw "Unable to set workflow in Configure Mode when running PowerShell in 'Non Interactive Mode'"
+        }
+    }
+
+    $ctx = Get-WorkflowContext
+    if ($PSCmdlet.ShouldProcess('Set-WorkflowInConfigureMode'))
+    {
+        $ctx.ConfigurePreference = $Value
+        $Global:ConfigurePreference = $Value
+    }
+}

--- a/src/Scriptbook/Public/Scriptbook/Variables.ps1
+++ b/src/Scriptbook/Public/Scriptbook/Variables.ps1
@@ -48,6 +48,7 @@ $Global:Context.Samples.Variable1 = 'newValue'
 #>
 function Variables
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "")]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)][string]$Name,
@@ -55,6 +56,8 @@ function Variables
         [Parameter(Position = 1)]
         [ScriptBlock]$Code
     )
+    if ($WhatIfPreference) { Write-Host "What if: Performing the operation 'Variables' on target '$Name'" }
+
     if ($Name -eq 'Variables') { Throw "Invalid Variables name found, '$Name' not allowed" }
 
     if ( !($Override.IsPresent) -and (Get-Variable -Name Context -ErrorAction Ignore -Scope Global) -and $Global:Context.ContainsKey($Name))
@@ -74,11 +77,11 @@ function Variables
         # create context
         if (!(Get-Variable -Name Context -ErrorAction Ignore -Scope Global))
         {
-            Set-Variable -Name Context -Value @{ } -Scope Global
+            Set-Variable -Name Context -Value @{ } -Scope Global -WhatIf:$false
         }
 
         $Global:Context."$Name" = $value
-        Set-Variable -Name $Name -Value $value -Scope Global
+        Set-Variable -Name $Name -Value $value -Scope Global -WhatIf:$false
     }
     catch
     {

--- a/src/Scriptbook/Public/Security/Get-LocalCredential.ps1
+++ b/src/Scriptbook/Public/Security/Get-LocalCredential.ps1
@@ -20,7 +20,7 @@ function Get-LocalCredential([Parameter(Mandatory = $true)][string]$Name)
     else
     {
         # not fail safe but better than nothing
-        if ( ((Get-Host).Name -eq 'ConsoleHost') -and ([bool]([Environment]::GetCommandLineArgs() -like '-noni*')) )
+        if (Get-IsPowerShellStartedInNonInteractiveMode)
         {
             Throw "Get-LocalCredential not working when running script in -NonInteractive Mode, unable to prompt for Credentials"
         }

--- a/src/Scriptbook/Public/Utilities/Get-IsPowerShellStartedInNonInteractiveMode.ps1
+++ b/src/Scriptbook/Public/Utilities/Get-IsPowerShellStartedInNonInteractiveMode.ps1
@@ -1,0 +1,19 @@
+<#
+.SYNOPSIS
+Returns if PowerShell console (pwsh) is started in Non Interactive mode
+
+.DESCRIPTION
+Returns if PowerShell console (pwsh) is started in Non Interactive mode
+
+#>
+function Get-IsPowerShellStartedInNonInteractiveMode
+{
+    if ( ((Get-Host).Name -eq 'ConsoleHost') -and ([bool]([Environment]::GetCommandLineArgs() -like '-noni*')) )
+    {
+        return $true
+    }
+        else
+    {
+        return $false
+    }
+}

--- a/src/Scriptbook/Public/Utilities/New-SecureStringStorage.ps1
+++ b/src/Scriptbook/Public/Utilities/New-SecureStringStorage.ps1
@@ -1,0 +1,7 @@
+function New-SecureStringStorage
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+    param([ValidateNotNullOrEmpty()]$String)
+
+    return [SecureStringStorage]::New($String)
+}

--- a/src/Scriptbook/Public/Utilities/SecureStringStorage.ps1
+++ b/src/Scriptbook/Public/Utilities/SecureStringStorage.ps1
@@ -1,0 +1,39 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+class SecureStringStorage
+{
+    hidden [String] $String
+    [String] $TypeName = 'SecureStringStorage'
+
+    SecureStringStorage($String)
+    {
+        if (($String -is [PSCustomObject]) -and ($String.TypeName -eq 'SecureStringStorage') )
+        {
+            $this.String = $String.String
+        }
+        elseif (($String -is [SecureString]))
+        {
+            $this.String = $String | ConvertFrom-SecureString
+        }
+        else
+        {
+            $this.String = ConvertTo-SecureString -String $String -AsPlainText -Force | ConvertFrom-SecureString
+        }
+    }
+
+    [string]ToString()
+    {
+        return $this.String
+    }
+
+    [SecureString]GetSecureString()
+    {
+        $secureString = ConvertTo-SecureString -String $this.String -Force
+        return $secureString
+    }
+
+    [string]GetPlainString()
+    {
+        $plain = ConvertTo-SecureString -String $this.String -Force | ConvertFrom-SecureString -AsPlainText
+        return $plain
+    }
+}

--- a/src/Scriptbook/Public/Utilities/Test-IsSecureStringStorageObject.ps1
+++ b/src/Scriptbook/Public/Utilities/Test-IsSecureStringStorageObject.ps1
@@ -1,0 +1,4 @@
+function Test-IsSecureStringStorageObject([ValidateNotNull()]$Object)
+{
+    return ($Object -is [SecureStringStorage])
+}

--- a/src/Scriptbook/Public/Utilities/Test-PSProperty.ps1
+++ b/src/Scriptbook/Public/Utilities/Test-PSProperty.ps1
@@ -17,6 +17,7 @@ Use exact match in property name checking
 #>
 function Test-PSProperty
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingEmptyCatchBlock", "")]
     [OutputType([boolean])]
     param([alias('o')][object]$Object, [alias('p')][string]$Name, [alias('e')][switch]$Exact)
 

--- a/src/Scriptbook/Scriptbook.psd1
+++ b/src/Scriptbook/Scriptbook.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'Scriptbook.psm1'
-    ModuleVersion     = '0.5.5'
+    ModuleVersion     = '0.6.0'
     GUID              = '05a95b01-2890-480f-a4ac-f40bc52d6c82'
     Author            = 'Edwin Hagen'
     CompanyName       = 'Tedon Technology BV'

--- a/src/Scriptbook/Scriptbook.psm1
+++ b/src/Scriptbook/Scriptbook.psm1
@@ -80,6 +80,7 @@ if ($core)
     }
 }
 
+$Global:ConfigurePreference = $false
 $Global:ScriptbookSimpleHost = $false
 if ($ImportVars -and $ImportVars.ContainsKey('SimpleHost'))
 {

--- a/src/tests/ScriptAnalyzerSettings.psd1
+++ b/src/tests/ScriptAnalyzerSettings.psd1
@@ -18,7 +18,7 @@
     # Use ExcludeRules when you want to run most of the default set of rules except
     # for a few rules you wish to "exclude".  Note: if a rule is in both IncludeRules
     # and ExcludeRules, the rule will be excluded.
-    ExcludeRules = @('PSUseToExportFieldsInManifest','PSMissingModuleManifestField','PSAvoidUsingWriteHost')
+    ExcludeRules = @('PSUseToExportFieldsInManifest','PSMissingModuleManifestField','PSAvoidUsingWriteHost','PSAvoidUsingCmdletAliases')
 
     # You can use the following entry to supply parameters to rules that take parameters.
     # For instance, the PSAvoidUsingCmdletAliases rule takes a whitelist for aliases you

--- a/src/tests/Scriptbook/scriptbook.simple.tests.ps1
+++ b/src/tests/Scriptbook/scriptbook.simple.tests.ps1
@@ -402,24 +402,27 @@ Describe 'Simple Workflows' {
         # assert
         $script:cnt | Should -Be 3
     }
-     
-    It 'Should run simple workflow with allow Action execution multiple times' {
+
+    It 'Should run simple workflow with allow Action execution multiple times and show verbose output' {
         # arrange
         $script:cnt = 0;
 
         # act
         Action Hello -Multiple {
             Write-Info "Hello"
+            'Hello from Verbose' | Out-Null
             $script:cnt++
         }
 
         Action Hello2 {
             Write-Info "Hello2"
+            'Hello2 from Verbose' | Out-Null
             $script:cnt++
         }
 
         Action Hello3 {
             Write-Info "Hello3"
+            'Hello3 from Verbose' | Out-Null
             Invoke-Action Hello
             Invoke-Action Hello
             $script:cnt++
@@ -427,15 +430,13 @@ Describe 'Simple Workflows' {
 
         Action GoodBy {
             Write-Info "GoodBy"
+            'Goodby from Verbose' | Out-Null
             $script:cnt++
         }
 
-        Start-Workflow -Name 'Workflow with Multiple times call action'
+        Start-Workflow -Name 'Workflow with Multiple times call action' -Verbose
 
         # assert
         $script:cnt | Should -Be 6
     }
-
-
-
 }

--- a/src/tests/Workflows/parameters-02.configure.ps1
+++ b/src/tests/Workflows/parameters-02.configure.ps1
@@ -1,0 +1,1 @@
+./parameters-02.start.ps1 -Configure

--- a/src/tests/Workflows/parameters-02.scriptbook.ps1
+++ b/src/tests/Workflows/parameters-02.scriptbook.ps1
@@ -1,0 +1,31 @@
+[CmdletBinding(SupportsShouldProcess = $True)]
+Param()
+
+Set-Location $PSScriptRoot
+
+Parameters -Name 'Params' -Path './parameters.default-params.json' {
+    @{
+        ParamOne = 'one'
+        ParamTwo = 'two'
+        ParamSecret = (ConvertTo-SecureString -String ('zcd7d0fcc926f073dff81de2c??') -AsPlainText -Force)
+    }
+}
+
+Variables -Name 'Samples' {
+    @{
+        ParamThree = 'three'
+    }
+}
+
+Action Hello {
+    $ctx = Get-WorkflowContext
+    Write-Info "Hello $($ctx.Params.ParamOne)"
+    Write-Info "Hello $($ctx.Params.ParamTwo)"
+}
+
+Action GoodBy {
+    $ctx = Get-WorkflowContext
+    Write-Info "GoodBy $($ctx.Samples.ParamThree)"
+}
+
+Start-Workflow -Name HelloWorkflow -WhatIf:$WhatIfPreference

--- a/src/tests/Workflows/parameters-02.start.ps1
+++ b/src/tests/Workflows/parameters-02.start.ps1
@@ -1,0 +1,11 @@
+[CmdletBinding()]
+param(
+    $Actions,
+    [switch]$Configure
+)
+
+Set-Location $PSScriptRoot
+
+Import-Module ../../Scriptbook/Scriptbook.psm1 -Force
+
+Start-Scriptbook -File ./parameters-02.scriptbook.ps1 -Actions $Actions -Parameters $parameters -Configure:$Configure


### PR DESCRIPTION
Added $ConfigurePreference & Edit Scriptbook parameters in Console Host (use -Configure parameter on Start-Scriptbook)
Added AsJob support to Start-Scriptbook
Added secure storage of secrets in json files to read/save parameters (from TD.Util)
Added not (!) support to Action expansion
Added warning loading Scriptbook module twice
Added Get-IsPowerShellStartedInNonInteractiveMode (Check running in console mode)
Added verbose support to Start-Workflow
Added verbose support to Out-Null (visible when in verbose mode)
Updated to Pester 5.* and codecoverage